### PR TITLE
Initial Alpine-based docker image for Miking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 Docker Environment for compiling and running miking/mcore programs. Each kind
 of image is placed under its own directory.
 
+## Dependencies
+
+The following dependencies are needed to build the docker images:
+
+* `docker` (with a running deamon in the background)
+* `make`
+* `sudo`
+
 # Build
 
 The images are configured to be built via makefiles. Build the image with its

--- a/README.md
+++ b/README.md
@@ -1,2 +1,73 @@
-# miking-docker
-Docker images for Miking
+# Miking Docker Images
+Docker Environment for compiling and running miking/mcore programs. Each kind
+of image is placed under its own directory.
+
+# Build
+
+The images are configured to be built via makefiles. Build the image with its
+Dockerfile in the directory `<DIR>` by running the following in at the
+top-level of the repository (the _build_ rule is optional and can be omitted):
+
+```sh
+make -C <DIR> build
+```
+
+For example, to build the `miking:<ver>-alpine` image, run make on its
+directory:
+
+```sh
+make -C miking-alpine build
+```
+
+This will also create the `miking:latest-alpine` tag for the created image. To
+tag an image as the latest miking image, use the `tag-latest` makefile rule.
+For example:
+
+```sh
+make -C miking-alpine tag-latest
+```
+
+This will create the tagged image `miking:latest`. This allows the instatiation
+of a container with the short-hand `miking` image name instead of writing the
+specific version.
+
+# Running the Image
+
+To verify that the build image can evaluate and compile MCore programs, the
+_test_ directory contains a _sample.mc_ program to test with.
+
+## Verify Evaluation
+
+Run the following command:
+
+```sh
+sudo docker run --rm -it -v $(pwd)/test:/mnt:ro miking:<ver> mi eval /mnt/sample.mc
+```
+
+This should produce the following output:
+
+```
+Found msg: "foo"
+Found msg: "bar"
+Found nothing.
+```
+
+## Verify Compilation
+
+**NOTE:** Compilation is highly specific to the target platform. If planning to
+run the compiled program outside the docker container, verify that your binary
+will work for your host environment by running `ldd <binary>`. Ideally,
+choosing an image version similar to the host system should produce a
+compatible binary.
+
+Run the following command to compile and run it:
+
+```sh
+sudo docker run --rm -it -v $(pwd)/test:/mnt:ro miking:<ver> bash -c "mi compile /mnt/sample.mc --output /tmp/sample && /tmp/sample"
+```
+
+This should produce the same output as for the evaluation case above. To export
+the compiled binary out from the container, either mount the /mnt folder
+without the ":ro" part or mount another folder that is writable from the
+container. Then change the `--output` flag to point to that directory instead
+of the /tmp directory.

--- a/miking-alpine/Dockerfile
+++ b/miking-alpine/Dockerfile
@@ -1,0 +1,54 @@
+FROM alpine:3.15.0
+
+RUN apk add bash
+
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /root
+
+# Add a nice PS1 for bash
+RUN echo "export PS1='\[\e]0;\u@\h: \w\a\]\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '" >> /root/.bashrc
+
+# Automatically show colors with ls
+RUN echo "alias ls='ls --color=auto'" >> /root/.bashrc
+
+# Where the built mi image will be placed
+RUN echo "export PATH=/root/.local/bin:\$PATH" >> /root/.bashrc
+
+# Install dependencies available through apk
+RUN apk add opam make m4 bubblewrap git rsync mercurial gcc g++ curl libexecinfo-dev linux-headers zlib-dev
+
+# Initialize opam
+RUN opam init --disable-sandboxing --auto-setup
+
+# Create the 4.12 environment
+RUN opam switch create 4.12.0+domains --packages=ocaml-variants.4.12.0+domains --repositories=multicore=git+https://github.com/ocaml-multicore/multicore-opam.git,default
+
+# Install dune and line noise
+RUN opam install -y dune linenoise
+
+# Add the opam environment as default
+RUN echo "eval \$(opam env)" >> /root/.bashrc
+
+# Download the latest version of the miking repository
+RUN cd /tmp && git clone https://github.com/miking-lang/miking
+
+WORKDIR /tmp/miking
+
+# Use the following commit as baseline
+RUN git checkout 1fabbca9a187e71f50c2c47c4b8eeb972313da15
+
+RUN eval $(opam env) && make install
+
+WORKDIR /root
+
+RUN rm -rf /tmp/miking
+
+# Export the opam env contents to docker ENV
+ENV PATH="/root/.opam/4.12.0+domains/bin:/root/.local/bin:$PATH"
+ENV MANPATH=":/root/.opam/4.12.0+domains/man"
+ENV OPAM_SWITCH_PREFIX="/root/.opam/4.12.0+domains"
+ENV CAML_LD_LIBRARY_PATH="/root/.opam/4.12.0+domains/lib/stublibs:/root/.opam/4.12.0+domains/lib/ocaml/stublibs:/root/.opam/4.12.0+domains/lib/ocaml"
+ENV OCAML_TOPLEVEL_PATH="/root/.opam/4.12.0+domains/lib/toplevel"
+
+CMD ["mi"]

--- a/miking-alpine/Makefile
+++ b/miking-alpine/Makefile
@@ -1,0 +1,4 @@
+# Setup distinction variables
+VERSION_SUFFIX=alpine
+
+include ../miking-common.mk

--- a/miking-common.mk
+++ b/miking-common.mk
@@ -1,0 +1,26 @@
+.PHONY: build run rm tag-latest
+
+# NOTE: VERSION_SUFFIX to be set in subfolders' Makefile
+
+IMAGENAME=miking
+VERSION=0.0.0-dev1-$(VERSION_SUFFIX)
+LATEST_VERSION=latest-$(VERSION_SUFFIX)
+
+build:
+	sudo docker build --tag $(IMAGENAME):$(VERSION) \
+	                  --force-rm \
+	                  --file Dockerfile \
+	                  ..
+	sudo docker tag $(IMAGENAME):$(VERSION) $(IMAGENAME):$(LATEST_VERSION)
+
+run:
+	sudo docker run --rm -it \
+	                --name $(IMAGENAME) \
+	                --hostname $(IMAGENAME) \
+	                $(IMAGENAME):$(VERSION)
+
+rm:
+	sudo docker rmi $(IMAGENAME):$(VERSION)
+
+tag-latest:
+	sudo docker tag $(IMAGENAME):$(VERSION) $(IMAGENAME):latest

--- a/test/sample.mc
+++ b/test/sample.mc
@@ -1,0 +1,23 @@
+-- sample.mc
+-- Sample program for verifying that the docker environment can compile and run
+-- MCore programs.
+
+-- import from standard library
+include "option.mc"
+include "seq.mc"
+
+let a = Some "foo"
+let b = Some "bar"
+let c = None ()
+
+let printContents = lam o.
+  switch o
+    case Some msg then print (join ["Found msg: \"", msg, "\"\n"])
+    case None _   then print "Found nothing.\n"
+  end
+
+mexpr
+
+printContents a;
+printContents b;
+printContents c


### PR DESCRIPTION
Contain an initial setup for building docker images based on Alpine Linux 3.15. Should not be too difficult to expand into images based on Ubuntu, Red Hat, etc. in the future.

A sample program is provided under the _test_ directory to verify the functionality of the build image.