### PR TITLE
Manifests for multi-architecture builds

### DIFF
--- a/baseline-alpine/Dockerfile
+++ b/baseline-alpine/Dockerfile
@@ -28,21 +28,25 @@ RUN mkdir -p /src/sundials \
  && cd /src \
  && rm -rf sundials
 
-ARG PLATFORM_OWL_CFLAGS
-ENV OWL_CFLAGS="-g -O3 -Ofast -funroll-loops -ffast-math -DSFMT_MEXP=19937 -fno-strict-aliasing -Wno-tautological-constant-out-of-range-compare ${PLATFORM_OWL_CFLAGS}"
-ENV OWL_AEOS_CFLAGS="-g -O3 -Ofast -funroll-loops -ffast-math -DSFMT_MEXP=19937 -fno-strict-aliasing"
-ENV EIGENCPP_OPTFLAGS="-Ofast -funroll-loops -ffast-math"
-ENV EIGEN_FLAGS="-O3 -Ofast -funroll-loops -ffast-math"
-
+ARG TARGETPLATFORM
 # NOTE: Running the opam setup as a single step to contain the downloading and
 #       cleaning of unwanted files in the same layer.
 # 1. Initialize opam
 RUN opam init --disable-sandboxing --auto-setup \
 # 2. Create the 5.0.0~rc1 environment
  && opam switch create miking-ocaml 5.0.0~rc1 \
-# 3. Install ocaml packages
+# 3. Setup platform compiler specific flags
+ && export OWL_CFLAGS="-g -O3 -Ofast -funroll-loops -ffast-math -DSFMT_MEXP=19937 -fno-strict-aliasing -Wno-tautological-constant-out-of-range-compare" \
+ && export OWL_AEOS_CFLAGS="-g -O3 -Ofast -funroll-loops -ffast-math -DSFMT_MEXP=19937 -fno-strict-aliasing" \
+ && export EIGENCPP_OPTFLAGS="-Ofast -funroll-loops -ffast-math" \
+ && export EIGEN_FLAGS="-O3 -Ofast -funroll-loops -ffast-math" \
+ && if [[ "$TARGETPLATFORM" == "linux/amd64" ]]; then \
+        export OWL_CFLAGS="$OWL_CFLAGS -mfpmath=sse -msse2"; \
+        echo "$OWL_CFLAGS" > /root/owlflags.txt; \
+    fi \
+# 4. Install ocaml packages
  && opam install -y --assume-depexts dune linenoise pyml toml lwt owl ocamlformat.0.24.1 \
-# 4. Install sundialsml manually (to ensure correct version)
+# 5. Install sundialsml manually (to ensure correct version)
  && eval $(opam env) \
  && mkdir -p /src/sundialsml \
  && cd /src/sundialsml \
@@ -54,7 +58,7 @@ RUN opam init --disable-sandboxing --auto-setup \
  && make install \
  && cd /src \
  && rm -rf sundialsml \
-# 5. Clean up stuff we no longer need
+# 6. Clean up stuff we no longer need
  && opam clean -rca \
  && rm -rf /root/.opam/repo           \
            /root/.opam/download-cache \

--- a/baseline-cuda/Dockerfile
+++ b/baseline-cuda/Dockerfile
@@ -37,20 +37,25 @@ RUN mkdir -p /src/sundials \
  && cd /src \
  && rm -rf sundials
 
-ENV OWL_CFLAGS="-g -O3 -Ofast -funroll-loops -ffast-math -DSFMT_MEXP=19937 -fno-strict-aliasing -Wno-tautological-constant-out-of-range-compare ${PLATFORM_OWL_CFLAGS}"
-ENV OWL_AEOS_CFLAGS="-g -O3 -Ofast -funroll-loops -ffast-math -DSFMT_MEXP=19937 -fno-strict-aliasing"
-ENV EIGENCPP_OPTFLAGS="-Ofast -funroll-loops -ffast-math"
-ENV EIGEN_FLAGS="-O3 -Ofast -funroll-loops -ffast-math"
-
+ARG TARGETPLATFORM
 # NOTE: Running the opam setup as a single step to contain the downloading and
 #       cleaning of unwanted files in the same layer.
 # 1. Initialize opam
 RUN opam init --disable-sandboxing --auto-setup \
 # 2. Create the 5.0.0~rc1 environment
  && opam switch create miking-ocaml 5.0.0~rc1 \
-# 3. Install ocaml packages
+# 3. Setup platform compiler specific flags
+ && export OWL_CFLAGS="-g -O3 -Ofast -funroll-loops -ffast-math -DSFMT_MEXP=19937 -fno-strict-aliasing -Wno-tautological-constant-out-of-range-compare" \
+ && export OWL_AEOS_CFLAGS="-g -O3 -Ofast -funroll-loops -ffast-math -DSFMT_MEXP=19937 -fno-strict-aliasing" \
+ && export EIGENCPP_OPTFLAGS="-Ofast -funroll-loops -ffast-math" \
+ && export EIGEN_FLAGS="-O3 -Ofast -funroll-loops -ffast-math" \
+ && if [[ "$TARGETPLATFORM" == "linux/amd64" ]]; then \
+        export OWL_CFLAGS="$OWL_CFLAGS -mfpmath=sse -msse2"; \
+        echo "$OWL_CFLAGS" > /root/owlflags.txt; \
+    fi \
+# 4. Install ocaml packages
  && opam install -y dune linenoise pyml toml lwt owl ocamlformat.0.24.1 \
-# 4. Install sundialsml manually (to ensure correct version)
+# 5. Install sundialsml manually (to ensure correct version)
  && eval $(opam env) \
  && mkdir -p /src/sundialsml \
  && cd /src/sundialsml \
@@ -62,7 +67,7 @@ RUN opam init --disable-sandboxing --auto-setup \
  && make install \
  && cd /src \
  && rm -rf sundialsml \
-# 5. Clean up stuff we no longer need
+# 6. Clean up stuff we no longer need
  && opam clean -rca \
  && rm -rf /root/.opam/repo           \
            /root/.opam/download-cache \

--- a/defs-common.mk
+++ b/defs-common.mk
@@ -15,3 +15,6 @@ BUILD_LOGDIR=../_logs
 
 MIKING_GIT_REMOTE="https://github.com/miking-lang/miking.git"
 MIKING_GIT_COMMIT="6628246936d9323b05175c2ab92f5026c232021c"
+
+VALIDATE_IMAGE_SCRIPT=../scripts/validate_image.py
+VALIDATE_ARCH_SCRIPT="../scripts/validate_architecture.py"

--- a/defs-miking.mk
+++ b/defs-miking.mk
@@ -1,4 +1,4 @@
-.PHONY: build run tag-latest rmi rmi-latest-version rmi-latest rmi-all
+.PHONY: build push run rmi rmi-latest-version rmi-latest rmi-all
 
 # Imports the following variables:
 #  - LATEST_VERSION

--- a/defs-miking.mk
+++ b/defs-miking.mk
@@ -72,13 +72,6 @@ push-manifests:
 		docker manifest push $(IMAGENAME):latest
 	fi
 
-#push:
-#	docker push $(IMAGENAME):$(VERSION)
-#	docker push $(IMAGENAME):$(LATEST_VERSION)
-#	if [[ "$(LATEST_VERSION)" == "$(LATEST_ALIAS)" ]]; then \
-#	    make push-latest; \
-#	fi
-
 run:
 	docker run --rm -it \
 	           --name miking \
@@ -86,14 +79,8 @@ run:
 	           $(IMAGENAME):$(VERSION) \
 	           bash
 
-#tag-latest:
-#	docker tag $(IMAGENAME):$(VERSION) $(IMAGENAME):latest
-
-#push-latest:
-#	docker push $(IMAGENAME):latest
-
 rmi:
-	docker rmi $(IMAGENAME):$(VERSION)
+	docker rmi $(IMAGENAME):$(VERSION)-$* $(IMAGENAME):$(VERSION)
 
 rmi-latest-version:
 	docker rmi $(IMAGENAME):$(LATEST_VERSION)

--- a/defs-miking.mk
+++ b/defs-miking.mk
@@ -68,8 +68,8 @@ push-manifests:
 	docker manifest push $(IMAGENAME):$(VERSION)
 	docker manifest push $(IMAGENAME):$(LATEST_VERSION)
 	if [[ "$(LATEST_VERSION)" == "$(LATEST_ALIAS)" ]]; then \
-		docker manifest create $(IMAGENAME):latest $(AMENDMENTS)
-		docker manifest push $(IMAGENAME):latest
+		docker manifest create $(IMAGENAME):latest $(AMENDMENTS); \
+		docker manifest push $(IMAGENAME):latest; \
 	fi
 
 run:


### PR DESCRIPTION
This adds some amendments to PR #8 to allow for multi-architecture images to be represented by the same tag. This is already on Docker Hub. But leaving this as Draft since I want to improve the documentation about this a bit more.

This changes the workflow such that you first build an image for each architecture as

```
make -C miking-<kind> build/<arch>
```

This will create the image `mikinglang/miking:<ver>-<kind>-<arch>` locally on your system. This can then be pushed to Docker Hub as

```
make -C miking-<kind> push/<arch>
```

Once the image has been built for all architectures and pushed to Docker Hub, then the manifests can be pushed to Docker Hub which will collect all architectures under a single tag:

```
make -C miking-<kind> push-manifests
```

Now the multi-arch tags `mikinglang/miking:<ver>-<kind>` and `mikinglang/miking:latest-<kind>` will be available on Docker Hub for multiple platforms.

I experimented a bit with using `buildx`, which has an arguably nicer interface and can build all architectures on single system. But the emulation aspect makes the docker build too slow when building the arm64 image on x86.