### PR TITLE
Update miking hash and image version

### DIFF
--- a/defs-common.mk
+++ b/defs-common.mk
@@ -5,7 +5,7 @@ MIKING_IMAGENAME=mikinglang/miking
 
 # NOTE: VERSION_SUFFIX to be set in subfolders' Makefile
 LATEST_VERSION=latest-$(VERSION_SUFFIX)
-MIKING_IMAGEVERSION=dev7-$(VERSION_SUFFIX)
+MIKING_IMAGEVERSION=dev8-$(VERSION_SUFFIX)
 BASELINE_IMAGEVERSION=v5-$(VERSION_SUFFIX)
 
 # The suffix for the version to be tagged with the `latest` alias
@@ -14,7 +14,7 @@ LATEST_ALIAS=latest-alpine
 BUILD_LOGDIR=../_logs
 
 MIKING_GIT_REMOTE="https://github.com/miking-lang/miking.git"
-MIKING_GIT_COMMIT="66b72cbe4678232858198a2b34c67222be46e627"
+MIKING_GIT_COMMIT="09c233080104f147a8fdd66fb63cfd6cfe8bf7b8"
 
 VALIDATE_IMAGE_SCRIPT=../scripts/validate_image.py
 VALIDATE_ARCH_SCRIPT="../scripts/validate_architecture.py"


### PR DESCRIPTION
Just updating the miking version to a later commit.

Validated builds:
- [x] miking-alpine (amd64 / x86_64)
- [x] miking-alpine (arm64 / M1 Mac)
- [x] miking-cuda (amd64 / x86_64)