### PR TITLE
Fix the issue with multiple digests for same architecture

### DIFF
--- a/defs-miking.mk
+++ b/defs-miking.mk
@@ -63,13 +63,17 @@ push-manifests:
 	 ))
 	echo $(AMENDMENTS)
 
+	# Using the || true since there is no -f option to `manifest rm`
+	docker manifest rm $(IMAGENAME):$(VERSION) || true
+	docker manifest rm $(IMAGENAME):$(LATEST_VERSION) || true
 	docker manifest create $(IMAGENAME):$(VERSION) $(AMENDMENTS)
 	docker manifest create $(IMAGENAME):$(LATEST_VERSION) $(AMENDMENTS)
-	docker manifest push $(IMAGENAME):$(VERSION)
-	docker manifest push $(IMAGENAME):$(LATEST_VERSION)
+	docker manifest push --purge $(IMAGENAME):$(VERSION)
+	docker manifest push --purge $(IMAGENAME):$(LATEST_VERSION)
 	if [[ "$(LATEST_VERSION)" == "$(LATEST_ALIAS)" ]]; then \
+		docker manifest rm $(IMAGENAME):latest || true; \
 		docker manifest create $(IMAGENAME):latest $(AMENDMENTS); \
-		docker manifest push $(IMAGENAME):latest; \
+		docker manifest push --purge $(IMAGENAME):latest; \
 	fi
 
 run:


### PR DESCRIPTION
Had an issue that the `latest`, `latest-alpine`, and `latest-cuda` tags on docker hub started accumulating digests from older builds. This was due to local manifests on my computer still remembering the previous builds. So now I remove the local manifests before creating any new manifests.