### PR TITLE
Update to latest commit and add JVM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 Docker Environment for compiling and running miking/mcore programs. Each kind
 of image is placed under its own directory.
 
+This readme contains development and build instructions only. For usage
+instructions, see the [Docker Hub README](docs/dockerhub-README.md) file in the
+`docs/` directory.
+
 ## Build Dependencies
 
 The following dependencies are needed to build the docker images:
 
-* `docker` (with a running deamon in the background)
+* `docker` (with a running Docker deamon in the background)
 * `make`
 * `sudo`
 
@@ -15,6 +19,14 @@ The following dependencies are needed to build the docker images:
 See CUDA Runtime Dependencies section in the dockerhub README under `docs/`. It
 is still possible to build the miking-cuda image without CUDA installed on the
 host system.
+
+# Table of Contents
+
+ * [Build](#build)
+ * [Running the Image](#running-the-image)
+   * [Verify Compilation](#verify-compilation)
+ * [Contributing](#contributing)
+   * [Pull Requests](#pull-requests)
 
 # Build
 
@@ -115,3 +127,32 @@ the compiled binary out from the container, either mount the /mnt folder
 without the ":ro" part or mount another folder that is writable from the
 container. Then change the `--output` flag to point to that directory instead
 of the /tmp directory.
+
+# Contributing
+
+To contribute to this repository, fork it, add your changes to a branch on your
+fork, submit your changes as a pull request from that branch.
+
+## Pull Requests
+
+Each pull request shall contain a record of all the targets that builds have
+been validated for. Copy paste this checklist to your PR description:
+
+```
+**Validated builds:**
+
+- [ ] miking-alpine (amd64 / x86_64)
+- [ ] miking-alpine (arm64 / M1 Mac)
+- [ ] miking-cuda (amd64 / x86_64)
+```
+
+It should look like this when formatted by GitHub:
+
+**Validated builds:**
+
+- [ ] miking-alpine (amd64 / x86_64)
+- [ ] miking-alpine (arm64 / M1 Mac)
+- [ ] miking-cuda (amd64 / x86_64)
+
+Tick each box once the build is validated. A build is validated when the miking
+image successfully builds with all tests passing.

--- a/baseline-alpine/Dockerfile
+++ b/baseline-alpine/Dockerfile
@@ -12,7 +12,7 @@ RUN echo "export PS1='\[\e]0;\u@\h: \w\a\]\[\033[01;32m\]\u@\h\[\033[00m\]:\[\03
  && echo "export PATH=/root/.local/bin:\$PATH" >> /root/.bashrc
 
 # Install dependencies available through apk
-RUN apk add opam make cmake m4 bubblewrap git rsync mercurial gcc g++ curl libexecinfo-dev linux-headers zlib-dev openblas-dev lapack-dev nodejs-current
+RUN apk add opam make cmake m4 bubblewrap git rsync mercurial gcc g++ curl libexecinfo-dev linux-headers zlib-dev openblas-dev lapack-dev nodejs-current openjdk17
 
 # Install sundials manually
 RUN mkdir -p /src/sundials \

--- a/baseline-cuda/Dockerfile
+++ b/baseline-cuda/Dockerfile
@@ -19,7 +19,7 @@ RUN DEBIAN_FRONTEND=noninteractive echo "Installing dependencies" \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC \
  && apt-get update \
  && ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime \
- && apt-get install -y curl time cmake wget unzip git rsync m4 mercurial nodejs libopenblas-dev liblapacke-dev pkg-config zlib1g-dev python3 libpython3-dev libtinfo-dev libgmp-dev build-essential curl libffi-dev libffi7 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 \
+ && apt-get install -y curl time cmake wget unzip git rsync m4 mercurial nodejs libopenblas-dev liblapacke-dev pkg-config zlib1g-dev python3 libpython3-dev libtinfo-dev libgmp-dev build-essential curl libffi-dev libffi7 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 openjdk-17-jdk \
  && curl -L -o /usr/local/bin/opam https://github.com/ocaml/opam/releases/download/2.1.2/opam-2.1.2-x86_64-linux \
  && chmod +x /usr/local/bin/opam
 

--- a/defs-common.mk
+++ b/defs-common.mk
@@ -5,8 +5,8 @@ MIKING_IMAGENAME=mikinglang/miking
 
 # NOTE: VERSION_SUFFIX to be set in subfolders' Makefile
 LATEST_VERSION=latest-$(VERSION_SUFFIX)
-MIKING_IMAGEVERSION=dev8-$(VERSION_SUFFIX)
-BASELINE_IMAGEVERSION=v5-$(VERSION_SUFFIX)
+MIKING_IMAGEVERSION=dev9-$(VERSION_SUFFIX)
+BASELINE_IMAGEVERSION=v6-$(VERSION_SUFFIX)
 
 # The suffix for the version to be tagged with the `latest` alias
 LATEST_ALIAS=latest-alpine
@@ -14,7 +14,7 @@ LATEST_ALIAS=latest-alpine
 BUILD_LOGDIR=../_logs
 
 MIKING_GIT_REMOTE="https://github.com/miking-lang/miking.git"
-MIKING_GIT_COMMIT="09c233080104f147a8fdd66fb63cfd6cfe8bf7b8"
+MIKING_GIT_COMMIT="73e2078e523f41bd51988016fe49841d5841716e"
 
 VALIDATE_IMAGE_SCRIPT=../scripts/validate_image.py
 VALIDATE_ARCH_SCRIPT="../scripts/validate_architecture.py"


### PR DESCRIPTION
Updates the commit hash to the latest available at the time (which includes the file namespacing). Also adds openjdk17 as a preinstalled dependency to run the JVM backend tests.

**Validated builds:**

- [x] miking-alpine (amd64 / x86_64)
- [x] miking-alpine (arm64 / M1 Mac)
- [x] miking-cuda (amd64 / x86_64)