### PR TITLE
Baseline push

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,29 +39,37 @@ make -C <DIR> build/<arch>
 ```
 
 Each miking image is based on a baseline image. **Before building a miking
-image, its corresponding baseline image has to be built.**
+image, its corresponding baseline image has to be built.** If the correct
+baseline image already exists on Docker Hub, that can be pulled directly
+instead and you can skip the "Baseline Image" step below.
 
-For example, before building the `miking-alpine` image, the matching
-`baseline-alpine` image has to be built first. Build it for amd64/x86_64 by
-running make on its directory:
+## Baseline Image
+
+Taking the alpine image as an example, before building the `miking-alpine`
+image, the matching `baseline-alpine` image has to be built first. Build it
+for amd64/x86_64 by running make on its directory:
 
 ```sh
 make -C baseline-alpine build/amd64
 ```
 
-This will create baseline image `mikinglang/baseline:<basever>-alpine` which
-contains all the necessary dependencies to build the miking compiler, but not
-the compiler itself. The `<arch>` part is necessary to specify some compiler
-options for certain dependencies. After the baseline image has been built, the
-`miking-alpine` image can now be built by running make on its directory:
+This will create baseline image `mikinglang/baseline:<basever>-alpine-amd64`
+which contains all the necessary dependencies to build the miking compiler, but
+not the compiler itself. The `<arch>` part is necessary to specify some
+compiler options for certain dependencies.
+
+## Miking Image
+
+After the baseline image has been built, the `miking-alpine` image can now be
+built by running make on its directory:
 
 ```sh
 make -C miking-alpine build/amd64
 ```
 
-This will create the versioned image `mikinglang/miking:<miver>-alpine`. This
-image can then be used directly, or pushed up to Docker Hub. To push it up to
-Docker Hub, make sure that you have push access to the mikinglang repository
+This will create the versioned image `mikinglang/miking:<miver>-alpine-amd64`.
+This image can then be used directly, or pushed up to Docker Hub. To push it up
+to Docker Hub, make sure that you have push access to the mikinglang repository
 and then run the make rule (replace `amd64` with the architecture of your
 platform):
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ host system.
 # Table of Contents
 
  * [Build](#build)
+   * [Baseline Image](#baseline-image)
+   * [Miking Image](#miking-image)
  * [Running the Image](#running-the-image)
    * [Verify Compilation](#verify-compilation)
  * [Contributing](#contributing)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ make -C <DIR> build/<arch>
 Each miking image is based on a baseline image. **Before building a miking
 image, its corresponding baseline image has to be built.** If the correct
 baseline image already exists on Docker Hub, that can be pulled directly
-instead and you can skip the "Baseline Image" step below.
+instead and you can skip the _Baseline Image_ step below.
 
 ## Baseline Image
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ which contains all the necessary dependencies to build the miking compiler, but
 not the compiler itself. The `<arch>` part is necessary to specify some
 compiler options for certain dependencies.
 
+This should then be pushed to Docker Hub. Do that by running the `push/<arch>`
+command for that image:
+
+```sh
+make -C baseline-alpine push/amd64
+```
+
 ## Miking Image
 
 After the baseline image has been built, the `miking-alpine` image can now be

--- a/defs-baseline.mk
+++ b/defs-baseline.mk
@@ -34,5 +34,12 @@ build/%:
 	             .. 2>&1 | tee -a $(LOGFILE)
 	$(VALIDATE_IMAGE_SCRIPT) --arch=$* $(IMAGENAME):$(VERSION)-$*
 
+push:
+	@echo -e "\033[1;31mSpecify the platform you are pushing for with \033[1;37mmake push/<arch>\033[0m"
+
+push/%:
+	$(VALIDATE_ARCH_SCRIPT) $*
+	docker push $(IMAGENAME):$(VERSION)-$*
+
 rmi:
 	docker rmi $(IMAGENAME):$(VERSION)


### PR DESCRIPTION
Add push rule for baseline images.

These are pushed to the new baseline repository on GitHub: https://hub.docker.com/r/mikinglang/baseline

Useful for reproducability.